### PR TITLE
Fix formating of comments in pretty print table macro

### DIFF
--- a/diesel_cli/src/pretty_printing.rs
+++ b/diesel_cli/src/pretty_printing.rs
@@ -53,15 +53,23 @@ pub fn format_schema(schema: &str) -> Result<String, FmtError> {
         // At this point, there is an empty line before `}`. We need to remove
         // the already inserted indent, because the new indent is smaller than
         // the old one.
-        if c == '}' {
-            while let Some(c) = out.pop() {
-                if c == '\n' {
-                    break;
+        match c {
+            '}' => {
+                while let Some(c) = out.pop() {
+                    if c == '\n' {
+                        break;
+                    }
                 }
-            }
 
-            indent.pop();
-            write!(out, "\n{}", indent)?;
+                indent.pop();
+                write!(out, "\n{}", indent)?;
+            }
+            '\n' => {
+                write!(out, "\n{}", indent)?;
+                skip_space = true;
+                continue;
+            }
+            _ => {}
         }
 
         // Keep track of our parenthesis level


### PR DESCRIPTION
This produces something like this: 
```rust
table! {
    /// Representation of the `versions` table.
    /// 
    /// (Generated by Diesel's `infer_schema!` macro.)
    versions (id) {
        /// The `id` column of the `versions` table.
        /// 
        /// Its SQL type is `Int8`.
        /// 
        /// (Generated by Diesel's `infer_schema!` macro.)
        id -> Int8,
        /// The `comment` column of the `versions` table.
        /// 
        /// Its SQL type is `Varchar`.
        /// 
        /// (Generated by Diesel's `infer_schema!` macro.)
        comment -> Varchar,
        /// The `commited_at` column of the `versions` table.
        /// 
        /// Its SQL type is `Timestamp`.
        /// 
        /// (Generated by Diesel's `infer_schema!` macro.)
        commited_at -> Timestamp,
    }
}

```